### PR TITLE
Fixed two translation errors inside of examples code

### DIFF
--- a/docs/clearing-the-screen.md
+++ b/docs/clearing-the-screen.md
@@ -53,7 +53,7 @@ void cls( HANDLE hConsole )
 
 // Get the number of character cells in the current buffer. 
 
-   if( !GetConsoleScreenBufferInfo( hConsole, &amp;csbi ))
+   if( !GetConsoleScreenBufferInfo( hConsole, &csbi ))
    {
       return;
    }
@@ -63,28 +63,28 @@ void cls( HANDLE hConsole )
    // Fill the entire screen with blanks.
 
    if( !FillConsoleOutputCharacter( hConsole,        // Handle to console screen buffer 
-                                    (TCHAR) &#39; &#39;,     // Character to write to the buffer
+                                    (TCHAR) ' ',     // Character to write to the buffer
                                     dwConSize,       // Number of cells to write 
                                     coordScreen,     // Coordinates of first cell 
-                                    &amp;cCharsWritten ))// Receive number of characters written
+                                    &cCharsWritten ))// Receive number of characters written
    {
       return;
    }
 
    // Get the current text attribute.
 
-   if( !GetConsoleScreenBufferInfo( hConsole, &amp;csbi ))
+   if( !GetConsoleScreenBufferInfo( hConsole, &csbi ))
    {
       return;
    }
 
-   // Set the buffer&#39;s attributes accordingly.
+   // Set the buffer's attributes accordingly.
 
    if( !FillConsoleOutputAttribute( hConsole,         // Handle to console screen buffer 
                                     csbi.wAttributes, // Character attributes to use
                                     dwConSize,        // Number of cells to set attribute 
                                     coordScreen,      // Coordinates of first cell 
-                                    &amp;cCharsWritten )) // Receive number of characters written
+                                    &cCharsWritten )) // Receive number of characters written
    {
       return;
    }

--- a/docs/console-virtual-terminal-sequences.md
+++ b/docs/console-virtual-terminal-sequences.md
@@ -598,7 +598,7 @@ int main()
     }
 
     DWORD dwMode = 0;
-    if (!GetConsoleMode(hOut, &amp;dwMode))
+    if (!GetConsoleMode(hOut, &dwMode))
     {
         return GetLastError();
     }
@@ -660,11 +660,11 @@ int main()
 
     DWORD dwOriginalOutMode = 0;
     DWORD dwOriginalInMode = 0;
-    if (!GetConsoleMode(hOut, &amp;dwOriginalOutMode))
+    if (!GetConsoleMode(hOut, &dwOriginalOutMode))
     {
         return false;
     }
-    if (!GetConsoleMode(hIn, &amp;dwOriginalInMode))
+    if (!GetConsoleMode(hIn, &dwOriginalInMode))
     {
         return false;
     }
@@ -680,7 +680,7 @@ int main()
         dwOutMode = dwOriginalOutMode | dwRequestedOutModes;
         if (!SetConsoleMode(hOut, dwOutMode))
         {
-            // Failed to set any VT mode, can&#39;t do anything here.
+            // Failed to set any VT mode, can't do anything here.
             return -1;
         }
     }
@@ -688,7 +688,7 @@ int main()
     DWORD dwInMode = dwOriginalInMode | ENABLE_VIRTUAL_TERMINAL_INPUT;
     if (!SetConsoleMode(hIn, dwInMode))
     {
-        // Failed to set VT input mode, can&#39;t do anything here.
+        // Failed to set VT input mode, can't do anything here.
         return -1;
     }
 
@@ -729,7 +729,7 @@ bool EnableVTMode()
     }
 
     DWORD dwMode = 0;
-    if (!GetConsoleMode(hOut, &amp;dwMode))
+    if (!GetConsoleMode(hOut, &dwMode))
     {
         return false;
     }
@@ -786,12 +786,12 @@ int __cdecl wmain(int argc, WCHAR* argv[])
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     if (hOut == INVALID_HANDLE_VALUE)
     {
-        printf("Couldn&#39;t get the console handle. Quitting.\n");
+        printf("Couldn't get the console handle. Quitting.\n");
         return -1;
     }
 
     CONSOLE_SCREEN_BUFFER_INFO ScreenBufferInfo;
-    GetConsoleScreenBufferInfo(hOut, &amp;ScreenBufferInfo);
+    GetConsoleScreenBufferInfo(hOut, &ScreenBufferInfo);
     COORD Size;
     Size.X = ScreenBufferInfo.srWindow.Right - ScreenBufferInfo.srWindow.Left + 1;
     Size.Y = ScreenBufferInfo.srWindow.Bottom -  ScreenBufferInfo.srWindow.Top + 1;
@@ -836,7 +836,7 @@ int __cdecl wmain(int argc, WCHAR* argv[])
     for (line = 0; line < iNumLines * iNumTabStops; line++)
     {
         PrintVerticalBorder();
-        if (line + 1 != iNumLines * iNumTabStops) // don&#39;t advance to next line if this is the last line
+        if (line + 1 != iNumLines * iNumTabStops) // don't advance to next line if this is the last line
             printf("\t"); // advance to next tab stop
 
     }
@@ -877,7 +877,7 @@ int __cdecl wmain(int argc, WCHAR* argv[])
         PrintVerticalBorder(); // print border at right side
         if (line+1 != iNumLines * 2)
         {
-            printf("\n"); //Advance to next line. If we&#39;re at the bottom of the margins, the text will scroll.
+            printf("\n"); //Advance to next line. If we're at the bottom of the margins, the text will scroll.
             printf("\r"); //return to first col in buffer
         }
     }

--- a/docs/reading-and-writing-blocks-of-characters-and-attributes.md
+++ b/docs/reading-and-writing-blocks-of-characters-and-attributes.md
@@ -89,7 +89,7 @@ int main(void)
        chiBuffer,      // buffer to copy into 
        coordBufSize,   // col-row size of chiBuffer 
        coordBufCoord,  // top left dest. cell in chiBuffer 
-       &amp;srctReadRect); // screen buffer source rectangle 
+       &srctReadRect); // screen buffer source rectangle 
     if (! fSuccess) 
     {
         printf("ReadConsoleOutput failed - (%d)\n", GetLastError()); 
@@ -110,7 +110,7 @@ int main(void)
         chiBuffer,        // buffer to copy from 
         coordBufSize,     // col-row size of chiBuffer 
         coordBufCoord,    // top left src cell in chiBuffer 
-        &amp;srctWriteRect);  // dest. screen buffer rectangle 
+        &srctWriteRect);  // dest. screen buffer rectangle 
     if (! fSuccess) 
     {
         printf("WriteConsoleOutput failed - (%d)\n", GetLastError()); 

--- a/docs/reading-input-buffer-events.md
+++ b/docs/reading-input-buffer-events.md
@@ -47,7 +47,7 @@ int main(VOID)
  
     // Save the current input mode, to be restored on exit. 
  
-    if (! GetConsoleMode(hStdin, &amp;fdwSaveOldMode) ) 
+    if (! GetConsoleMode(hStdin, &fdwSaveOldMode) ) 
         ErrorExit("GetConsoleMode"); 
 
     // Enable the window and mouse input events. 
@@ -66,7 +66,7 @@ int main(VOID)
                 hStdin,      // input buffer handle 
                 irInBuf,     // buffer to read into 
                 128,         // size of read buffer 
-                &amp;cNumRead) ) // number of records read 
+                &cNumRead) ) // number of records read 
             ErrorExit("ReadConsoleInput"); 
  
         // Dispatch the events to the appropriate handler. 

--- a/docs/scrolling-a-screen-buffer-s-contents.md
+++ b/docs/scrolling-a-screen-buffer-s-contents.md
@@ -53,7 +53,7 @@ int main( void )
  
     // Get the screen buffer size. 
  
-    if (!GetConsoleScreenBufferInfo(hStdout, &amp;csbiInfo)) 
+    if (!GetConsoleScreenBufferInfo(hStdout, &csbiInfo)) 
     {
         printf("GetConsoleScreenBufferInfo failed %d\n", GetLastError()); 
         return 1;
@@ -80,16 +80,16 @@ int main( void )
     // Fill the bottom row with green blanks. 
  
     chiFill.Attributes = BACKGROUND_GREEN | FOREGROUND_RED; 
-    chiFill.Char.AsciiChar = (char)&#39; &#39;; 
+    chiFill.Char.AsciiChar = (char)' '; 
  
     // Scroll up one line. 
  
     if(!ScrollConsoleScreenBuffer(  
         hStdout,         // screen buffer handle 
-        &amp;srctScrollRect, // scrolling rectangle 
-        &amp;srctClipRect,   // clipping rectangle 
+        &srctScrollRect, // scrolling rectangle 
+        &srctClipRect,   // clipping rectangle 
         coordDest,       // top left destination cell 
-        &amp;chiFill))       // fill character and color
+        &chiFill))       // fill character and color
     {
         printf("ScrollConsoleScreenBuffer failed %d\n", GetLastError()); 
         return 1;

--- a/docs/scrolling-a-screen-buffer-s-window.md
+++ b/docs/scrolling-a-screen-buffer-s-window.md
@@ -37,7 +37,7 @@ int ScrollByAbsoluteCoord(int iRows)
  
     // Get the current screen buffer size and window position. 
  
-    if (! GetConsoleScreenBufferInfo(hStdout, &amp;csbiInfo)) 
+    if (! GetConsoleScreenBufferInfo(hStdout, &csbiInfo)) 
     {
         printf("GetConsoleScreenBufferInfo (%d)\n", GetLastError()); 
         return 0;
@@ -57,7 +57,7 @@ int ScrollByAbsoluteCoord(int iRows)
         if (! SetConsoleWindowInfo( 
                    hStdout,          // screen buffer handle 
                    TRUE,             // absolute coordinates 
-                   &amp;srctWindow))     // specifies new location 
+                   &srctWindow))     // specifies new location 
         {
             printf("SetConsoleWindowInfo (%d)\n", GetLastError()); 
             return 0;
@@ -78,7 +78,7 @@ int ScrollByRelativeCoord(int iRows)
 
     // Get the current screen buffer window position. 
  
-    if (! GetConsoleScreenBufferInfo(hStdout, &amp;csbiInfo)) 
+    if (! GetConsoleScreenBufferInfo(hStdout, &csbiInfo)) 
     {
         printf("GetConsoleScreenBufferInfo (%d)\n", GetLastError()); 
         return 0;
@@ -96,7 +96,7 @@ int ScrollByRelativeCoord(int iRows)
         if (! SetConsoleWindowInfo( 
                    hStdout,          // screen buffer handle 
                    FALSE,            // relative coordinates
-                   &amp;srctWindow))     // specifies new location 
+                   &srctWindow))     // specifies new location 
         {
             printf("SetConsoleWindowInfo (%d)\n", GetLastError()); 
             return 0;

--- a/docs/using-the-high-level-input-and-output-functions.md
+++ b/docs/using-the-high-level-input-and-output-functions.md
@@ -56,7 +56,7 @@ int main(void)
 
     // Save the current text colors. 
 
-    if (! GetConsoleScreenBufferInfo(hStdout, &amp;csbiInfo)) 
+    if (! GetConsoleScreenBufferInfo(hStdout, &csbiInfo)) 
     {
         MessageBox(NULL, TEXT("GetConsoleScreenBufferInfo"), 
             TEXT("Console Error"), MB_OK); 
@@ -88,7 +88,7 @@ int main(void)
             hStdout,               // output handle 
             lpszPrompt1,           // prompt string 
             lstrlenA(lpszPrompt1), // string length 
-            &amp;cWritten,             // bytes written 
+            &cWritten,             // bytes written 
             NULL) )                // not overlapped 
         {
             MessageBox(NULL, TEXT("WriteFile"), TEXT("Console Error"), 
@@ -100,22 +100,22 @@ int main(void)
             hStdin,    // input handle 
             chBuffer,  // buffer to read into 
             255,       // size of buffer 
-            &amp;cRead,    // actual bytes read 
+            &cRead,    // actual bytes read 
             NULL) )    // not overlapped 
         break; 
-        if (chBuffer[0] == &#39;q&#39;) break; 
+        if (chBuffer[0] == 'q') break; 
     } 
 
     // Turn off the line input and echo input modes 
 
-    if (! GetConsoleMode(hStdin, &amp;fdwOldMode)) 
+    if (! GetConsoleMode(hStdin, &fdwOldMode)) 
     {
        MessageBox(NULL, TEXT("GetConsoleMode"), TEXT("Console Error"),
            MB_OK); 
        return 1;
     }
 
-    fdwMode = fdwOldMode &amp; 
+    fdwMode = fdwOldMode & 
         ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT); 
     if (! SetConsoleMode(hStdin, fdwMode)) 
     {
@@ -135,7 +135,7 @@ int main(void)
             hStdout,               // output handle 
             lpszPrompt2,           // prompt string 
             lstrlenA(lpszPrompt2), // string length 
-            &amp;cWritten,             // bytes written 
+            &cWritten,             // bytes written 
             NULL) )                // not overlapped 
         {
             MessageBox(NULL, TEXT("WriteFile"), TEXT("Console Error"), 
@@ -143,15 +143,15 @@ int main(void)
             return 1;
         }
 
-        if (! ReadFile(hStdin, chBuffer, 1, &amp;cRead, NULL)) 
+        if (! ReadFile(hStdin, chBuffer, 1, &cRead, NULL)) 
             break; 
-        if (chBuffer[0] == &#39;\r&#39;)
+        if (chBuffer[0] == '\r')
             NewLine();
         else if (! WriteFile(hStdout, chBuffer, cRead, 
-            &amp;cWritten, NULL)) break;
+            &cWritten, NULL)) break;
         else
             NewLine();
-        if (chBuffer[0] == &#39;q&#39;) break; 
+        if (chBuffer[0] == 'q') break; 
     } 
 
     // Restore the original console mode. 
@@ -171,7 +171,7 @@ int main(void)
  
 void NewLine(void) 
 { 
-    if (! GetConsoleScreenBufferInfo(hStdout, &amp;csbiInfo)) 
+    if (! GetConsoleScreenBufferInfo(hStdout, &csbiInfo)) 
     {
         MessageBox(NULL, TEXT("GetConsoleScreenBufferInfo"), 
             TEXT("Console Error"), MB_OK); 
@@ -225,16 +225,16 @@ void ScrollScreenBuffer(HANDLE h, INT x)
     // Set the fill character and attributes. 
  
     chiFill.Attributes = FOREGROUND_RED|FOREGROUND_INTENSITY; 
-    chiFill.Char.AsciiChar = (char)&#39; &#39;; 
+    chiFill.Char.AsciiChar = (char)' '; 
  
     // Scroll up one line. 
  
     ScrollConsoleScreenBuffer( 
         h,               // screen buffer handle 
-        &amp;srctScrollRect, // scrolling rectangle 
-        &amp;srctClipRect,   // clipping rectangle 
+        &srctScrollRect, // scrolling rectangle 
+        &srctClipRect,   // clipping rectangle 
         coordDest,       // top left destination cell 
-        &amp;chiFill);       // fill character and color 
+        &chiFill);       // fill character and color 
 }
 ```
 


### PR DESCRIPTION
Changed the markdown ampersand " & a m p ; " to & and " & # 3 9 ; " to '
They're shown with spaces so they don't get interpreted by mark down.