### PR TITLE
Three minor formatting issues

### DIFF
--- a/docs/console-buffer-security-and-access-rights.md
+++ b/docs/console-buffer-security-and-access-rights.md
@@ -25,7 +25,7 @@ You can specify a [security descriptor](https://msdn.microsoft.com/library/windo
 
 The handles returned by [**CreateFile**](https://msdn.microsoft.com/library/windows/desktop/aa363858), [**CreateConsoleScreenBuffer**](createconsolescreenbuffer.md), and [**GetStdHandle**](getstdhandle.md) have the **GENERIC\_READ** and **GENERIC\_WRITE** access rights.
 
-The valid access rights include the **GENERIC\_READ** and **GENERIC\_WRITE**[generic access rights](https://msdn.microsoft.com/library/windows/desktop/aa446632).
+The valid access rights include the **GENERIC\_READ** and **GENERIC\_WRITE** [generic access rights](https://msdn.microsoft.com/library/windows/desktop/aa446632).
 
 | Value                            | Meaning                                                                                               |
 |----------------------------------|-------------------------------------------------------------------------------------------------------|

--- a/docs/readconsole.md
+++ b/docs/readconsole.md
@@ -91,7 +91,7 @@ This function uses either Unicode characters or 8-bit characters from the consol
 
 The *pInputControl* parameter can be used to enable intermediate wakeups from the read in response to a file-completion control character specified in a [**CONSOLE\_READCONSOLE\_CONTROL**](console-readconsole-control.md) structure. This feature requires command extensions to be enabled, the standard output handle to be a console output handle, and input to be Unicode.
 
-**Windows Server 2003 and Windows XP/2000:  **The intermediate read feature is not supported.
+**Windows Server 2003 and Windows XP/2000:** The intermediate read feature is not supported.
 
 Requirements
 ------------

--- a/docs/setconsolectrlhandler.md
+++ b/docs/setconsolectrlhandler.md
@@ -83,7 +83,7 @@ A console process can use the [**GenerateConsoleCtrlEvent**](generateconsolectrl
 
 The system generates **CTRL\_CLOSE\_EVENT**, **CTRL\_LOGOFF\_EVENT**, and **CTRL\_SHUTDOWN\_EVENT** signals when the user closes the console, logs off, or shuts down the system so that the process has an opportunity to clean up before termination. Console functions, or any C run-time functions that call console functions, may not work reliably during processing of any of the three signals mentioned previously. The reason is that some or all of the internal console cleanup routines may have been called before executing the process signal handler.
 
-**Windows 7, Windows 8, Windows 8.1 and Windows 10:  **
+**Windows 7, Windows 8, Windows 8.1 and Windows 10:**
 
 If a console application loads the gdi32.dll or user32.dll library, the [**HandlerRoutine**](handlerroutine.md) function that you specify when you call **SetConsoleCtrlHandler** does not get called for the **CTRL\_LOGOFF\_EVENT** and **CTRL\_SHUTDOWN\_EVENT** events. The operating system recognizes processes that load gdi32.dll or user32.dll as Windows applications rather than console applications. This behavior also occurs for console applications that do not call functions in gdi32.dll or user32.dll directly, but do call functions such as [Shell functions](https://msdn.microsoft.com/library/windows/desktop/bb776426) that do in turn call functions in gdi32.dll or user32.dll.
 


### PR DESCRIPTION
Incorrectly placed asterisks in **ReadConsole** and **SetConsoleCtrlHandler** docs.
Also a space was missing between two words in **Console Buffer Security and Access Rights**.