### PR TITLE
Remove descriptions of a shared heap buffer. 

### DIFF
--- a/docs/getconsoleoriginaltitle.md
+++ b/docs/getconsoleoriginaltitle.md
@@ -47,8 +47,6 @@ Parameters
 *lpConsoleTitle* \[out\]  
 A pointer to a buffer that receives a null-terminated string containing the original title.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nSize* \[in\]  
 The size of the *lpConsoleTitle* buffer, in characters.
 

--- a/docs/getconsoleprocesslist.md
+++ b/docs/getconsoleprocesslist.md
@@ -46,8 +46,6 @@ Parameters
 *lpdwProcessList* \[out\]  
 A pointer to a buffer that receives an array of process identifiers upon success.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *dwProcessCount* \[in\]  
 The maximum number of process identifiers that can be stored in the *lpdwProcessList* buffer.
 

--- a/docs/getconsoletitle.md
+++ b/docs/getconsoletitle.md
@@ -53,8 +53,6 @@ Parameters
 *lpConsoleTitle* \[out\]  
 A pointer to a buffer that receives a null-terminated string containing the title. If the buffer is too small to store the title, the function stores as many characters of the title as will fit in the buffer, ending with a null terminator.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nSize* \[in\]  
 The size of the buffer pointed to by the *lpConsoleTitle* parameter, in characters.
 

--- a/docs/peekconsoleinput.md
+++ b/docs/peekconsoleinput.md
@@ -58,8 +58,6 @@ A handle to the console input buffer. The handle must have the **GENERIC\_READ**
 *lpBuffer* \[out\]  
 A pointer to an array of [**INPUT\_RECORD**](input-record-str.md) structures that receives the input buffer data.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nLength* \[in\]  
 The size of the array pointed to by the *lpBuffer* parameter, in array elements.
 

--- a/docs/readconsole.md
+++ b/docs/readconsole.md
@@ -58,8 +58,6 @@ A handle to the console input buffer. The handle must have the **GENERIC\_READ**
 *lpBuffer* \[out\]  
 A pointer to a buffer that receives the data read from the console input buffer.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nNumberOfCharsToRead* \[in\]  
 The number of characters to be read. The size of the buffer pointed to by the *lpBuffer* parameter should be at least `nNumberOfCharsToRead * sizeof(TCHAR)` bytes.
 

--- a/docs/readconsoleinput.md
+++ b/docs/readconsoleinput.md
@@ -57,8 +57,6 @@ A handle to the console input buffer. The handle must have the **GENERIC\_READ**
 *lpBuffer* \[out\]  
 A pointer to an array of [**INPUT\_RECORD**](input-record-str.md) structures that receives the input buffer data.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nLength* \[in\]  
 The size of the array pointed to by the *lpBuffer* parameter, in array elements.
 

--- a/docs/readconsoleoutput.md
+++ b/docs/readconsoleoutput.md
@@ -57,8 +57,6 @@ A handle to the console screen buffer. The handle must have the **GENERIC\_READ*
 *lpBuffer* \[out\]  
 A pointer to a destination buffer that receives the data read from the console screen buffer. This pointer is treated as the origin of a two-dimensional array of [**CHAR\_INFO**](char-info-str.md) structures whose size is specified by the *dwBufferSize* parameter.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *dwBufferSize* \[in\]  
 The size of the *lpBuffer* parameter, in character cells. The **X** member of the [**COORD**](coord-str.md) structure is the number of columns; the **Y** member is the number of rows.
 

--- a/docs/readconsoleoutputattribute.md
+++ b/docs/readconsoleoutputattribute.md
@@ -55,8 +55,6 @@ A handle to the console screen buffer. The handle must have the **GENERIC\_READ*
 *lpAttribute* \[out\]  
 A pointer to a buffer that receives the attributes being used by the console screen buffer.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 For more information, see [Character Attributes](console-screen-buffers.md#_win32_font_attributes).
 
 *nLength* \[in\]  

--- a/docs/readconsoleoutputcharacter.md
+++ b/docs/readconsoleoutputcharacter.md
@@ -57,8 +57,6 @@ A handle to the console screen buffer. The handle must have the **GENERIC\_READ*
 *lpCharacter* \[out\]  
 A pointer to a buffer that receives the characters read from the console screen buffer.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nLength* \[in\]  
 The number of screen buffer character cells from which to read. The size of the buffer pointed to by the *lpCharacter* parameter should be `nLength * sizeof(TCHAR)`.
 

--- a/docs/writeconsole.md
+++ b/docs/writeconsole.md
@@ -58,8 +58,6 @@ A handle to the console screen buffer. The handle must have the **GENERIC\_WRITE
 *lpBuffer* \[in\]  
 A pointer to a buffer that contains characters to be written to the console screen buffer.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nNumberOfCharsToWrite* \[in\]  
 The number of characters to be written. If the total size of the specified number of characters exceeds the available heap, the function fails with **ERROR\_NOT\_ENOUGH\_MEMORY**.
 

--- a/docs/writeconsoleinput.md
+++ b/docs/writeconsoleinput.md
@@ -56,8 +56,6 @@ A handle to the console input buffer. The handle must have the **GENERIC\_WRITE*
 *lpBuffer* \[in\]  
 A pointer to an array of [**INPUT\_RECORD**](input-record-str.md) structures that contain data to be written to the input buffer.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nLength* \[in\]  
 The number of input records to be written.
 

--- a/docs/writeconsoleoutput.md
+++ b/docs/writeconsoleoutput.md
@@ -57,8 +57,6 @@ A handle to the console screen buffer. The handle must have the **GENERIC\_WRITE
 *lpBuffer* \[in\]  
 The data to be written to the console screen buffer. This pointer is treated as the origin of a two-dimensional array of [**CHAR\_INFO**](char-info-str.md) structures whose size is specified by the *dwBufferSize* parameter.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *dwBufferSize* \[in\]  
 The size of the buffer pointed to by the *lpBuffer* parameter, in character cells. The **X** member of the [**COORD**](coord-str.md) structure is the number of columns; the **Y** member is the number of rows.
 

--- a/docs/writeconsoleoutputattribute.md
+++ b/docs/writeconsoleoutputattribute.md
@@ -58,8 +58,6 @@ The attributes to be used when writing to the console screen buffer. For more in
 *nLength* \[in\]  
 The number of screen buffer character cells to which the attributes will be copied.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *dwWriteCoord* \[in\]  
 A [**COORD**](coord-str.md) structure that specifies the character coordinates of the first cell in the console screen buffer to which the attributes will be written.
 

--- a/docs/writeconsoleoutputcharacter.md
+++ b/docs/writeconsoleoutputcharacter.md
@@ -56,8 +56,6 @@ A handle to the console screen buffer. The handle must have the **GENERIC\_WRITE
 *lpCharacter* \[in\]  
 The characters to be written to the console screen buffer.
 
-The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size. The maximum size of the buffer will depend on heap usage.
-
 *nLength* \[in\]  
 The number of characters to be written.
 


### PR DESCRIPTION
In today's version of these APIs, the buffers are allocated by the callers.