### PR TITLE
Change language on code blocks to 'C'

### DIFF
--- a/docs/addconsolealias.md
+++ b/docs/addconsolealias.md
@@ -33,7 +33,7 @@ Defines a console alias for the specified executable.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI AddConsoleAlias(
   _In_ LPCTSTR Source,
   _In_ LPCTSTR Target,

--- a/docs/allocconsole.md
+++ b/docs/allocconsole.md
@@ -36,7 +36,7 @@ Allocates a new console for the calling process.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI AllocConsole(void);
 ```
 

--- a/docs/attachconsole.md
+++ b/docs/attachconsole.md
@@ -35,7 +35,7 @@ Attaches the calling process to the console of the specified process.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI AttachConsole(
   _In_ DWORD dwProcessId
 );

--- a/docs/char-info-str.md
+++ b/docs/char-info-str.md
@@ -32,7 +32,7 @@ Specifies a Unicode or ANSI character and its attributes. This structure is used
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CHAR_INFO {
   union {
     WCHAR UnicodeChar;

--- a/docs/clearing-the-screen.md
+++ b/docs/clearing-the-screen.md
@@ -26,7 +26,7 @@ There are two ways to clear the screen in a console application.
 
 The first method is to use the C run-time **system** function. The **system** function invokes the **cls** command provided by the command interpreter to clear the screen.
 
-```ManagedCPlusPlus
+```C
 #include <stdlib.h>
 
 int main( void )
@@ -41,7 +41,7 @@ int main( void )
 
 The second method is to write a function to programmatically clear the screen using the [**FillConsoleOutputCharacter**](fillconsoleoutputcharacter.md) and [**FillConsoleOutputAttribute**](fillconsoleoutputattribute.md) functions. The following sample code demonstrates this technique.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h>
 
 void cls( HANDLE hConsole )

--- a/docs/console-cursor-info-str.md
+++ b/docs/console-cursor-info-str.md
@@ -33,7 +33,7 @@ Contains information about the console cursor.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CONSOLE_CURSOR_INFO {
   DWORD dwSize;
   BOOL  bVisible;

--- a/docs/console-font-info-str.md
+++ b/docs/console-font-info-str.md
@@ -32,7 +32,7 @@ Contains information for a console font.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CONSOLE_FONT_INFO {
   DWORD nFont;
   COORD dwFontSize;

--- a/docs/console-font-infoex.md
+++ b/docs/console-font-infoex.md
@@ -32,7 +32,7 @@ Contains extended information for a console font.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CONSOLE_FONT_INFOEX {
   ULONG cbSize;
   DWORD nFont;

--- a/docs/console-history-info.md
+++ b/docs/console-history-info.md
@@ -32,7 +32,7 @@ Contains information about the console history.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct {
   UINT  cbSize;
   UINT  HistoryBufferSize;

--- a/docs/console-readconsole-control.md
+++ b/docs/console-readconsole-control.md
@@ -32,7 +32,7 @@ Contains information for a console read operation.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CONSOLE_READCONSOLE_CONTROL {
   ULONG nLength;
   ULONG nInitialChars;

--- a/docs/console-screen-buffer-info-str.md
+++ b/docs/console-screen-buffer-info-str.md
@@ -33,7 +33,7 @@ Contains information about a console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CONSOLE_SCREEN_BUFFER_INFO {
   COORD      dwSize;
   COORD      dwCursorPosition;

--- a/docs/console-screen-buffer-infoex.md
+++ b/docs/console-screen-buffer-infoex.md
@@ -32,7 +32,7 @@ Contains extended information about a console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CONSOLE_SCREEN_BUFFER_INFOEX {
   ULONG      cbSize;
   COORD      dwSize;

--- a/docs/console-selection-info-str.md
+++ b/docs/console-selection-info-str.md
@@ -33,7 +33,7 @@ Contains information for a console selection.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _CONSOLE_SELECTION_INFO {
   DWORD      dwFlags;
   COORD      dwSelectionAnchor;

--- a/docs/console-virtual-terminal-sequences.md
+++ b/docs/console-virtual-terminal-sequences.md
@@ -554,7 +554,7 @@ The following code provides an example of the recommended way to enable virtual 
 
 2. SetConsoleMode returning with STATUS\_INVALID\_PARAMETER is the current mechanism to determine when running on a down-level system. An application receiving STATUS\_INVALID\_PARAMETER with one of the newer console mode flags in the bit field should gracefully degrade behavior and try again.
 
-```ManagedCPlusPlus
+```C
 #include <stdio.h>
 #include <wchar.h>
 #include <windows.h>
@@ -617,7 +617,7 @@ The following example is intended to be a more robust example of code using a va
 
 This example makes use of the alternate screen buffer, manipulating tab stops, setting scrolling margins, and changing the character set.
 
-```ManagedCPlusPlus
+```C
 //
 //    Copyright (C) Microsoft.  All rights reserved.
 //

--- a/docs/coord-str.md
+++ b/docs/coord-str.md
@@ -33,7 +33,7 @@ Defines the coordinates of a character cell in a console screen buffer. The orig
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _COORD {
   SHORT X;
   SHORT Y;

--- a/docs/createconsolescreenbuffer.md
+++ b/docs/createconsolescreenbuffer.md
@@ -36,7 +36,7 @@ Creates a console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 HANDLE WINAPI CreateConsoleScreenBuffer(
   _In_             DWORD               dwDesiredAccess,
   _In_             DWORD               dwShareMode,

--- a/docs/fillconsoleoutputattribute.md
+++ b/docs/fillconsoleoutputattribute.md
@@ -36,7 +36,7 @@ Sets the character attributes for a specified number of character cells, beginni
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI FillConsoleOutputAttribute(
   _In_  HANDLE  hConsoleOutput,
   _In_  WORD    wAttribute,

--- a/docs/fillconsoleoutputcharacter.md
+++ b/docs/fillconsoleoutputcharacter.md
@@ -38,7 +38,7 @@ Writes a character to the console screen buffer a specified number of times, beg
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI FillConsoleOutputCharacter(
   _In_  HANDLE  hConsoleOutput,
   _In_  TCHAR   cCharacter,

--- a/docs/flushconsoleinputbuffer.md
+++ b/docs/flushconsoleinputbuffer.md
@@ -35,7 +35,7 @@ Flushes the console input buffer. All input records currently in the input buffe
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI FlushConsoleInputBuffer(
   _In_ HANDLE hConsoleInput
 );

--- a/docs/focus-event-record-str.md
+++ b/docs/focus-event-record-str.md
@@ -33,7 +33,7 @@ Describes a focus event in a console [**INPUT\_RECORD**](input-record-str.md) st
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _FOCUS_EVENT_RECORD {
   BOOL bSetFocus;
 } FOCUS_EVENT_RECORD;

--- a/docs/freeconsole.md
+++ b/docs/freeconsole.md
@@ -36,7 +36,7 @@ Detaches the calling process from its console.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI FreeConsole(void);
 ```
 

--- a/docs/generateconsolectrlevent.md
+++ b/docs/generateconsolectrlevent.md
@@ -36,7 +36,7 @@ Sends a specified signal to a console process group that shares the console asso
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GenerateConsoleCtrlEvent(
   _In_ DWORD dwCtrlEvent,
   _In_ DWORD dwProcessGroupId

--- a/docs/getconsolealias.md
+++ b/docs/getconsolealias.md
@@ -34,7 +34,7 @@ Retrieves the text for the specified console alias and executable.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 DWORD WINAPI GetConsoleAlias(
   _In_  LPTSTR lpSource,
   _Out_ LPTSTR lpTargetBuffer,

--- a/docs/getconsolealiases.md
+++ b/docs/getconsolealiases.md
@@ -34,7 +34,7 @@ Retrieves all defined console aliases for the specified executable.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 DWORD WINAPI GetConsoleAliases(
   _Out_ LPTSTR lpAliasBuffer,
   _In_  DWORD  AliasBufferLength,

--- a/docs/getconsolealiaseslength.md
+++ b/docs/getconsolealiaseslength.md
@@ -34,7 +34,7 @@ Retrieves the required size for the buffer used by the [**GetConsoleAliases**](g
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 DWORD WINAPI GetConsoleAliasesLength(
   _In_ LPTSTR lpExeName
 );

--- a/docs/getconsolealiasexes.md
+++ b/docs/getconsolealiasexes.md
@@ -34,7 +34,7 @@ Retrieves the names of all executable files with console aliases defined.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 DWORD WINAPI GetConsoleAliasExes(
   _Out_ LPTSTR lpExeNameBuffer,
   _In_  DWORD  ExeNameBufferLength

--- a/docs/getconsolealiasexeslength.md
+++ b/docs/getconsolealiasexeslength.md
@@ -34,7 +34,7 @@ Retrieves the required size for the buffer used by the [**GetConsoleAliasExes**]
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 DWORD WINAPI GetConsoleAliasExesLength(void);
 ```
 

--- a/docs/getconsolecp.md
+++ b/docs/getconsolecp.md
@@ -37,7 +37,7 @@ Retrieves the input code page used by the console associated with the calling pr
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 UINT WINAPI GetConsoleCP(void);
 ```
 

--- a/docs/getconsolecursorinfo.md
+++ b/docs/getconsolecursorinfo.md
@@ -36,7 +36,7 @@ Retrieves information about the size and visibility of the cursor for the specif
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetConsoleCursorInfo(
   _In_  HANDLE               hConsoleOutput,
   _Out_ PCONSOLE_CURSOR_INFO lpConsoleCursorInfo

--- a/docs/getconsoledisplaymode.md
+++ b/docs/getconsoledisplaymode.md
@@ -33,7 +33,7 @@ Retrieves the display mode of the current console.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetConsoleDisplayMode(
   _Out_ LPDWORD lpModeFlags
 );

--- a/docs/getconsolefontsize.md
+++ b/docs/getconsolefontsize.md
@@ -33,7 +33,7 @@ Retrieves the size of the font used by the specified console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 COORD WINAPI GetConsoleFontSize(
   _In_ HANDLE hConsoleOutput,
   _In_ DWORD  nFont

--- a/docs/getconsolehistoryinfo.md
+++ b/docs/getconsolehistoryinfo.md
@@ -32,7 +32,7 @@ Retrieves the history settings for the calling process's console.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetConsoleHistoryInfo(
   _Out_ PCONSOLE_HISTORY_INFO lpConsoleHistoryInfo
 );

--- a/docs/getconsolemode.md
+++ b/docs/getconsolemode.md
@@ -37,7 +37,7 @@ Retrieves the current input mode of a console's input buffer or the current outp
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetConsoleMode(
   _In_  HANDLE  hConsoleHandle,
   _Out_ LPDWORD lpMode

--- a/docs/getconsoleoriginaltitle.md
+++ b/docs/getconsoleoriginaltitle.md
@@ -34,7 +34,7 @@ Retrieves the original title for the current console window.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 DWORD WINAPI GetConsoleOriginalTitle(
   _Out_ LPTSTR lpConsoleTitle,
   _In_  DWORD  nSize

--- a/docs/getconsoleoutputcp.md
+++ b/docs/getconsoleoutputcp.md
@@ -37,7 +37,7 @@ Retrieves the output code page used by the console associated with the calling p
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 UINT WINAPI GetConsoleOutputCP(void);
 ```
 

--- a/docs/getconsoleprocesslist.md
+++ b/docs/getconsoleprocesslist.md
@@ -33,7 +33,7 @@ Retrieves a list of the processes attached to the current console.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 DWORD WINAPI GetConsoleProcessList(
   _Out_ LPDWORD lpdwProcessList,
   _In_  DWORD   dwProcessCount

--- a/docs/getconsolescreenbufferinfo.md
+++ b/docs/getconsolescreenbufferinfo.md
@@ -26,7 +26,7 @@ Retrieves information about the specified console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetConsoleScreenBufferInfo(
   _In_  HANDLE                      hConsoleOutput,
   _Out_ PCONSOLE_SCREEN_BUFFER_INFO lpConsoleScreenBufferInfo

--- a/docs/getconsolescreenbufferinfoex.md
+++ b/docs/getconsolescreenbufferinfoex.md
@@ -35,7 +35,7 @@ Retrieves extended information about the specified console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetConsoleScreenBufferInfoEx(
   _In_  HANDLE                        hConsoleOutput,
   _Out_ PCONSOLE_SCREEN_BUFFER_INFOEX lpConsoleScreenBufferInfoEx

--- a/docs/getconsoleselectioninfo.md
+++ b/docs/getconsoleselectioninfo.md
@@ -33,7 +33,7 @@ Retrieves information about the current console selection.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetConsoleSelectionInfo(
   _Out_ PCONSOLE_SELECTION_INFO lpConsoleSelectionInfo
 );

--- a/docs/getconsoletitle.md
+++ b/docs/getconsoletitle.md
@@ -40,7 +40,7 @@ Retrieves the title for the current console window.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C++
 DWORD WINAPI GetConsoleTitle(
   _Out_ LPTSTR lpConsoleTitle,
   _In_  DWORD  nSize

--- a/docs/getconsoletitle.md
+++ b/docs/getconsoletitle.md
@@ -40,7 +40,7 @@ Retrieves the title for the current console window.
 Syntax
 ------
 
-```C++
+```C
 DWORD WINAPI GetConsoleTitle(
   _Out_ LPTSTR lpConsoleTitle,
   _In_  DWORD  nSize

--- a/docs/getconsolewindow.md
+++ b/docs/getconsolewindow.md
@@ -41,7 +41,7 @@ Retrieves the window handle used by the console associated with the calling proc
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 HWND WINAPI GetConsoleWindow(void);
 ```
 

--- a/docs/getcurrentconsolefont.md
+++ b/docs/getcurrentconsolefont.md
@@ -33,7 +33,7 @@ Retrieves information about the current console font.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetCurrentConsoleFont(
   _In_  HANDLE             hConsoleOutput,
   _In_  BOOL               bMaximumWindow,

--- a/docs/getcurrentconsolefontex.md
+++ b/docs/getcurrentconsolefontex.md
@@ -32,7 +32,7 @@ Retrieves extended information about the current console font.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetCurrentConsoleFontEx(
   _In_  HANDLE               hConsoleOutput,
   _In_  BOOL                 bMaximumWindow,

--- a/docs/getlargestconsolewindowsize.md
+++ b/docs/getlargestconsolewindowsize.md
@@ -36,7 +36,7 @@ Retrieves the size of the largest possible console window, based on the current 
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 COORD WINAPI GetLargestConsoleWindowSize(
   _In_ HANDLE hConsoleOutput
 );

--- a/docs/getnumberofconsoleinputevents.md
+++ b/docs/getnumberofconsoleinputevents.md
@@ -37,7 +37,7 @@ Retrieves the number of unread input records in the console's input buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetNumberOfConsoleInputEvents(
   _In_  HANDLE  hConsoleInput,
   _Out_ LPDWORD lpcNumberOfEvents

--- a/docs/getnumberofconsolemousebuttons.md
+++ b/docs/getnumberofconsolemousebuttons.md
@@ -33,7 +33,7 @@ Retrieves the number of buttons on the mouse used by the current console.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI GetNumberOfConsoleMouseButtons(
   _Out_ LPDWORD lpNumberOfMouseButtons
 );

--- a/docs/getstdhandle.md
+++ b/docs/getstdhandle.md
@@ -38,7 +38,7 @@ Retrieves a handle to the specified standard device (standard input, standard ou
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 HANDLE WINAPI GetStdHandle(
   _In_ DWORD nStdHandle
 );

--- a/docs/handlerroutine.md
+++ b/docs/handlerroutine.md
@@ -35,7 +35,7 @@ The **PHANDLER\_ROUTINE** type defines a pointer to this callback function. **Ha
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI HandlerRoutine(
   _In_ DWORD dwCtrlType
 );

--- a/docs/input-record-str.md
+++ b/docs/input-record-str.md
@@ -33,7 +33,7 @@ Describes an input event in the console input buffer. These records can be read 
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _INPUT_RECORD {
   WORD  EventType;
   union {

--- a/docs/key-event-record-str.md
+++ b/docs/key-event-record-str.md
@@ -33,7 +33,7 @@ Describes a keyboard input event in a console [**INPUT\_RECORD**](input-record-s
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _KEY_EVENT_RECORD {
   BOOL  bKeyDown;
   WORD  wRepeatCount;

--- a/docs/menu-event-record-str.md
+++ b/docs/menu-event-record-str.md
@@ -33,7 +33,7 @@ Describes a menu event in a console [**INPUT\_RECORD**](input-record-str.md) str
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _MENU_EVENT_RECORD {
   UINT dwCommandId;
 } MENU_EVENT_RECORD, *PMENU_EVENT_RECORD;

--- a/docs/mouse-event-record-str.md
+++ b/docs/mouse-event-record-str.md
@@ -33,7 +33,7 @@ Describes a mouse input event in a console [**INPUT\_RECORD**](input-record-str.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _MOUSE_EVENT_RECORD {
   COORD dwMousePosition;
   DWORD dwButtonState;

--- a/docs/peekconsoleinput.md
+++ b/docs/peekconsoleinput.md
@@ -40,7 +40,7 @@ Reads data from the specified console input buffer without removing it from the 
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI PeekConsoleInput(
   _In_  HANDLE        hConsoleInput,
   _Out_ PINPUT_RECORD lpBuffer,

--- a/docs/readconsole.md
+++ b/docs/readconsole.md
@@ -39,7 +39,7 @@ Reads character input from the console input buffer and removes it from the buff
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI ReadConsole(
   _In_     HANDLE  hConsoleInput,
   _Out_    LPVOID  lpBuffer,

--- a/docs/readconsoleinput.md
+++ b/docs/readconsoleinput.md
@@ -39,7 +39,7 @@ Reads data from a console input buffer and removes it from the buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI ReadConsoleInput(
   _In_  HANDLE        hConsoleInput,
   _Out_ PINPUT_RECORD lpBuffer,

--- a/docs/readconsoleoutput.md
+++ b/docs/readconsoleoutput.md
@@ -38,7 +38,7 @@ Reads character and color attribute data from a rectangular block of character c
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI ReadConsoleOutput(
   _In_    HANDLE      hConsoleOutput,
   _Out_   PCHAR_INFO  lpBuffer,

--- a/docs/readconsoleoutputattribute.md
+++ b/docs/readconsoleoutputattribute.md
@@ -36,7 +36,7 @@ Copies a specified number of character attributes from consecutive cells of a co
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI ReadConsoleOutputAttribute(
   _In_  HANDLE  hConsoleOutput,
   _Out_ LPWORD  lpAttribute,

--- a/docs/readconsoleoutputcharacter.md
+++ b/docs/readconsoleoutputcharacter.md
@@ -38,7 +38,7 @@ Copies a number of characters from consecutive cells of a console screen buffer,
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI ReadConsoleOutputCharacter(
   _In_  HANDLE  hConsoleOutput,
   _Out_ LPTSTR  lpCharacter,

--- a/docs/reading-and-writing-blocks-of-characters-and-attributes.md
+++ b/docs/reading-and-writing-blocks-of-characters-and-attributes.md
@@ -23,7 +23,7 @@ The [**ReadConsoleOutput**](readconsoleoutput.md) function copies a rectangular 
 
 The following example uses the [**CreateConsoleScreenBuffer**](createconsolescreenbuffer.md) function to create a new screen buffer. After the [**SetConsoleActiveScreenBuffer**](setconsoleactivescreenbuffer.md) function makes this the active screen buffer, a block of characters and color attributes is copied from the top two rows of the STDOUT screen buffer into a temporary buffer. The data is then copied from the temporary buffer into the new active screen buffer. When the application is finished using the new screen buffer, it calls **SetConsoleActiveScreenBuffer** to restore the original STDOUT screen buffer.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h> 
 #include <stdio.h>
  

--- a/docs/reading-input-buffer-events.md
+++ b/docs/reading-input-buffer-events.md
@@ -21,7 +21,7 @@ ms.assetid: 57570f3b-4a37-4789-bf6c-474fae60171d
 
 The [**ReadConsoleInput**](readconsoleinput.md) function can be used to directly access a console's input buffer. When a console is created, mouse input is enabled and window input is disabled. To ensure that the process receives all types of events, this example uses the [**SetConsoleMode**](setconsolemode.md) function to enable window and mouse input. Then it goes into a loop that reads and handles 100 console input events. For example, the message "Keyboard event" is displayed when the user presses a key and the message "Mouse event" is displayed when the user interacts with the mouse.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h>
 #include <stdio.h>
 

--- a/docs/registering-a-control-handler-function.md
+++ b/docs/registering-a-control-handler-function.md
@@ -27,7 +27,7 @@ When a **CTRL\_CLOSE\_EVENT** signal is received, the control handler returns **
 
 When a **CTRL\_BREAK\_EVENT**, **CTRL\_LOGOFF\_EVENT**, or **CTRL\_SHUTDOWN\_EVENT** signal is received, the control handler returns **FALSE**. Doing this causes the signal to be passed to the next control handler function. If no other control handlers have been registered or none of the registered handlers returns **TRUE**, the default handler will be used, resulting in the process being terminated.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h> 
 #include <stdio.h> 
  

--- a/docs/scrollconsolescreenbuffer.md
+++ b/docs/scrollconsolescreenbuffer.md
@@ -34,7 +34,7 @@ Moves a block of data in a screen buffer. The effects of the move can be limited
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI ScrollConsoleScreenBuffer(
   _In_           HANDLE     hConsoleOutput,
   _In_     const SMALL_RECT *lpScrollRectangle,

--- a/docs/scrolling-a-screen-buffer-s-contents.md
+++ b/docs/scrolling-a-screen-buffer-s-contents.md
@@ -25,7 +25,7 @@ The [**ScrollConsoleScreenBuffer**](scrollconsolescreenbuffer.md) function moves
 
 The following example shows the use of a clipping rectangle to scroll only the bottom 15 rows of the console screen buffer. The rows in the specified rectangle are scrolled up one line at a time, and the top row of the block is discarded. The contents of the console screen buffer outside the clipping rectangle are left unchanged.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h>
 #include <stdio.h>
 

--- a/docs/scrolling-a-screen-buffer-s-window.md
+++ b/docs/scrolling-a-screen-buffer-s-window.md
@@ -23,7 +23,7 @@ The [**SetConsoleWindowInfo**](setconsolewindowinfo.md) function can be used to 
 
 The following example scrolls the view of the console screen buffer up by modifying the window coordinates returned by the [**GetConsoleScreenBufferInfo**](getconsolescreenbufferinfo.md) function. The `ScrollByAbsoluteCoord` function demonstrates how to specify absolute coordinates, while the `ScrollByRelativeCoord` function demonstrates how to specify relative coordinates.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h>
 #include <stdio.h>
 #include <conio.h>

--- a/docs/setconsoleactivescreenbuffer.md
+++ b/docs/setconsoleactivescreenbuffer.md
@@ -36,7 +36,7 @@ Sets the specified screen buffer to be the currently displayed console screen bu
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleActiveScreenBuffer(
   _In_ HANDLE hConsoleOutput
 );

--- a/docs/setconsolecp.md
+++ b/docs/setconsolecp.md
@@ -36,7 +36,7 @@ Sets the input code page used by the console associated with the calling process
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleCP(
   _In_ UINT wCodePageID
 );

--- a/docs/setconsolectrlhandler.md
+++ b/docs/setconsolectrlhandler.md
@@ -39,7 +39,7 @@ If no handler function is specified, the function sets an inheritable attribute 
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleCtrlHandler(
   _In_opt_ PHANDLER_ROUTINE HandlerRoutine,
   _In_     BOOL             Add

--- a/docs/setconsolecursorinfo.md
+++ b/docs/setconsolecursorinfo.md
@@ -36,7 +36,7 @@ Sets the size and visibility of the cursor for the specified console screen buff
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleCursorInfo(
   _In_       HANDLE              hConsoleOutput,
   _In_ const CONSOLE_CURSOR_INFO *lpConsoleCursorInfo

--- a/docs/setconsolecursorposition.md
+++ b/docs/setconsolecursorposition.md
@@ -36,7 +36,7 @@ Sets the cursor position in the specified console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleCursorPosition(
   _In_ HANDLE hConsoleOutput,
   _In_ COORD  dwCursorPosition

--- a/docs/setconsoledisplaymode.md
+++ b/docs/setconsoledisplaymode.md
@@ -32,7 +32,7 @@ Sets the display mode of the specified console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleDisplayMode(
   _In_      HANDLE hConsoleOutput,
   _In_      DWORD  dwFlags,

--- a/docs/setconsolehistoryinfo.md
+++ b/docs/setconsolehistoryinfo.md
@@ -32,7 +32,7 @@ Sets the history settings for the calling process's console.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleHistoryInfo(
   _In_ PCONSOLE_HISTORY_INFO lpConsoleHistoryInfo
 );

--- a/docs/setconsolemode.md
+++ b/docs/setconsolemode.md
@@ -37,7 +37,7 @@ Sets the input mode of a console's input buffer or the output mode of a console 
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleMode(
   _In_ HANDLE hConsoleHandle,
   _In_ DWORD  dwMode

--- a/docs/setconsoleoutputcp.md
+++ b/docs/setconsoleoutputcp.md
@@ -36,7 +36,7 @@ Sets the output code page used by the console associated with the calling proces
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleOutputCP(
   _In_ UINT wCodePageID
 );

--- a/docs/setconsolescreenbufferinfoex.md
+++ b/docs/setconsolescreenbufferinfoex.md
@@ -35,7 +35,7 @@ Sets extended information about the specified console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleScreenBufferInfoEx(
   _In_ HANDLE                        hConsoleOutput,
   _In_ PCONSOLE_SCREEN_BUFFER_INFOEX lpConsoleScreenBufferInfoEx

--- a/docs/setconsolescreenbuffersize.md
+++ b/docs/setconsolescreenbuffersize.md
@@ -36,7 +36,7 @@ Changes the size of the specified console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleScreenBufferSize(
   _In_ HANDLE hConsoleOutput,
   _In_ COORD  dwSize

--- a/docs/setconsoletextattribute.md
+++ b/docs/setconsoletextattribute.md
@@ -36,7 +36,7 @@ Sets the attributes of characters written to the console screen buffer by the [*
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleTextAttribute(
   _In_ HANDLE hConsoleOutput,
   _In_ WORD   wAttributes

--- a/docs/setconsoletitle.md
+++ b/docs/setconsoletitle.md
@@ -46,7 +46,7 @@ Sets the title for the current console window.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleTitle(
   _In_ LPCTSTR lpConsoleTitle
 );
@@ -77,7 +77,7 @@ Examples
 
 The following example shows how to retrieve and modify the console title.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h>
 #include <tchar.h>
 #include <conio.h>

--- a/docs/setconsolewindowinfo.md
+++ b/docs/setconsolewindowinfo.md
@@ -36,7 +36,7 @@ Sets the current size and position of a console screen buffer's window.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetConsoleWindowInfo(
   _In_       HANDLE     hConsoleOutput,
   _In_       BOOL       bAbsolute,

--- a/docs/setcurrentconsolefontex.md
+++ b/docs/setcurrentconsolefontex.md
@@ -32,7 +32,7 @@ Sets extended information about the current console font.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI SetCurrentConsoleFontEx(
   _In_ HANDLE               hConsoleOutput,
   _In_ BOOL                 bMaximumWindow,

--- a/docs/small-rect-str.md
+++ b/docs/small-rect-str.md
@@ -35,7 +35,7 @@ Defines the coordinates of the upper left and lower right corners of a rectangle
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _SMALL_RECT {
   SHORT Left;
   SHORT Top;

--- a/docs/using-the-high-level-input-and-output-functions.md
+++ b/docs/using-the-high-level-input-and-output-functions.md
@@ -25,7 +25,7 @@ The example assumes that the default I/O modes are in effect initially for the f
 
 The example's `NewLine` function is used when line input mode is disabled. It handles carriage returns by moving the cursor position to the first cell of the next row. If the cursor is already in the last row of the console screen buffer, the contents of the console screen buffer are scrolled up one line.
 
-```ManagedCPlusPlus
+```C
 #include <windows.h> 
  
 void NewLine(void); 

--- a/docs/window-buffer-size-record-str.md
+++ b/docs/window-buffer-size-record-str.md
@@ -33,7 +33,7 @@ Describes a change in the size of the console screen buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 typedef struct _WINDOW_BUFFER_SIZE_RECORD {
   COORD dwSize;
 } WINDOW_BUFFER_SIZE_RECORD;

--- a/docs/writeconsole.md
+++ b/docs/writeconsole.md
@@ -39,7 +39,7 @@ Writes a character string to a console screen buffer beginning at the current cu
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI WriteConsole(
   _In_             HANDLE  hConsoleOutput,
   _In_       const VOID    *lpBuffer,

--- a/docs/writeconsoleinput.md
+++ b/docs/writeconsoleinput.md
@@ -38,7 +38,7 @@ Writes data directly to the console input buffer.
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI WriteConsoleInput(
   _In_        HANDLE       hConsoleInput,
   _In_  const INPUT_RECORD *lpBuffer,

--- a/docs/writeconsoleoutput.md
+++ b/docs/writeconsoleoutput.md
@@ -38,7 +38,7 @@ Writes character and color attribute data to a specified rectangular block of ch
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI WriteConsoleOutput(
   _In_          HANDLE      hConsoleOutput,
   _In_    const CHAR_INFO   *lpBuffer,

--- a/docs/writeconsoleoutputattribute.md
+++ b/docs/writeconsoleoutputattribute.md
@@ -36,7 +36,7 @@ Copies a number of character attributes to consecutive cells of a console screen
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI WriteConsoleOutputAttribute(
   _In_        HANDLE  hConsoleOutput,
   _In_  const WORD    *lpAttribute,

--- a/docs/writeconsoleoutputcharacter.md
+++ b/docs/writeconsoleoutputcharacter.md
@@ -37,7 +37,7 @@ Copies a number of characters to consecutive cells of a console screen buffer, b
 Syntax
 ------
 
-```ManagedCPlusPlus
+```C
 BOOL WINAPI WriteConsoleOutputCharacter(
   _In_  HANDLE  hConsoleOutput,
   _In_  LPCTSTR lpCharacter,


### PR DESCRIPTION
Our APIs are actually just straight C functions.
Also the `ManagedCPlusPlus` declaration isn't working to highlight anything.
Did a find and replace on all files, checked the highlighting through Open Publishing and it's now coloring `const` and function names (which is better than the nothing it was highlighting before.)