### PR TITLE
Updated sample

### DIFF
--- a/docs/registering-a-control-handler-function.md
+++ b/docs/registering-a-control-handler-function.md
@@ -28,63 +28,68 @@ When a **CTRL\_CLOSE\_EVENT** signal is received, the control handler returns **
 When a **CTRL\_BREAK\_EVENT**, **CTRL\_LOGOFF\_EVENT**, or **CTRL\_SHUTDOWN\_EVENT** signal is received, the control handler returns **FALSE**. Doing this causes the signal to be passed to the next control handler function. If no other control handlers have been registered or none of the registered handlers returns **TRUE**, the default handler will be used, resulting in the process being terminated.
 
 ```C
+// CtrlHandler.cpp : This file contains the 'main' function. Program execution begins and ends there.
+//
+
+#include "pch.h"
+
 #include <windows.h> 
 #include <stdio.h> 
- 
-BOOL CtrlHandler( DWORD fdwCtrlType ) 
-{ 
-  switch( fdwCtrlType ) 
-  { 
-    // Handle the CTRL-C signal. 
-    case CTRL_C_EVENT: 
-      printf( "Ctrl-C event\n\n" );
-      Beep( 750, 300 ); 
-      return( TRUE );
- 
-    // CTRL-CLOSE: confirm that the user wants to exit. 
-    case CTRL_CLOSE_EVENT: 
-      Beep( 600, 200 ); 
-      printf( "Ctrl-Close event\n\n" );
-      return( TRUE ); 
- 
-    // Pass other signals to the next handler. 
-    case CTRL_BREAK_EVENT: 
-      Beep( 900, 200 ); 
-      printf( "Ctrl-Break event\n\n" );
-      return FALSE; 
- 
-    case CTRL_LOGOFF_EVENT: 
-      Beep( 1000, 200 ); 
-      printf( "Ctrl-Logoff event\n\n" );
-      return FALSE; 
- 
-    case CTRL_SHUTDOWN_EVENT: 
-      Beep( 750, 500 ); 
-      printf( "Ctrl-Shutdown event\n\n" );
-      return FALSE; 
- 
-    default: 
-      return FALSE; 
-  } 
-} 
- 
-int main( void ) 
-{ 
-  if( SetConsoleCtrlHandler( (PHANDLER_ROUTINE) CtrlHandler, TRUE ) ) 
-  { 
-    printf( "\nThe Control Handler is installed.\n" ); 
-    printf( "\n -- Now try pressing Ctrl+C or Ctrl+Break, or" ); 
-    printf( "\n    try logging off or closing the console...\n" ); 
-    printf( "\n(...waiting in a loop for events...)\n\n" ); 
- 
-    while( 1 ){ } 
-  } 
-  else 
-  {
-    printf( "\nERROR: Could not set control handler"); 
-    return 1;
-  }
-return 0;
+
+BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
+{
+    switch (fdwCtrlType)
+    {
+        // Handle the CTRL-C signal. 
+    case CTRL_C_EVENT:
+        printf("Ctrl-C event\n\n");
+        Beep(750, 300);
+        return TRUE;
+
+        // CTRL-CLOSE: confirm that the user wants to exit. 
+    case CTRL_CLOSE_EVENT:
+        Beep(600, 200);
+        printf("Ctrl-Close event\n\n");
+        return TRUE;
+
+        // Pass other signals to the next handler. 
+    case CTRL_BREAK_EVENT:
+        Beep(900, 200);
+        printf("Ctrl-Break event\n\n");
+        return TRUE;
+
+    case CTRL_LOGOFF_EVENT:
+        Beep(1000, 200);
+        printf("Ctrl-Logoff event\n\n");
+        return FALSE;
+
+    case CTRL_SHUTDOWN_EVENT:
+        Beep(750, 500);
+        printf("Ctrl-Shutdown event\n\n");
+        return FALSE;
+
+    default:
+        return FALSE;
+    }
+}
+
+int main(void)
+{
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
+    {
+        printf("\nThe Control Handler is installed.\n");
+        printf("\n -- Now try pressing Ctrl+C or Ctrl+Break, or");
+        printf("\n    try logging off or closing the console...\n");
+        printf("\n(...waiting in a loop for events...)\n\n");
+
+        while (1) {}
+    }
+    else
+    {
+        printf("\nERROR: Could not set control handler");
+        return 1;
+    }
+    return 0;
 }
 ```
 


### PR DESCRIPTION
* Declared `CtrlHandler(...)` as `WINAPI` to eliminate need for `PHANDLER_ROUTINE` cast.
* Changed `CTRL` + `BREAK` handler to return `TRUE` so the app doesn't quit!