### PR TITLE
Add extra detail to console font info ex structure per #55

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Tools/NuGet/
 packages.config
 
 .vs/
+.vscode/

--- a/docs/console-font-infoex.md
+++ b/docs/console-font-infoex.md
@@ -47,7 +47,7 @@ Members
 -------
 
 **cbSize**  
-The size of this structure, in bytes.
+The size of this structure, in bytes. This member must be set to `sizeof(CONSOLE_FONT_INFOEX)` before calling [**GetCurrentConsoleFontEx**](getcurrentconsolefontex.md) or it will fail.
 
 **nFont**  
 The index of the font in the system's console font table.


### PR DESCRIPTION
Adds an extra piece of detail to the `cbSize` member of the `CONSOLE_FONT_INFOEX` structure to provide clarity for the person requesting a change in issue #55. 