### PR TITLE
Add additional commentary to `GetConsoleProcessList` document to refl…

### DIFF
--- a/docs/getconsoleprocesslist.md
+++ b/docs/getconsoleprocesslist.md
@@ -43,10 +43,10 @@ Parameters
 ----------
 
 *lpdwProcessList* \[out\]  
-A pointer to a buffer that receives an array of process identifiers upon success.
+A pointer to a buffer that receives an array of process identifiers upon success. This must be a valid buffer and cannot be `NULL`.
 
 *dwProcessCount* \[in\]  
-The maximum number of process identifiers that can be stored in the *lpdwProcessList* buffer.
+The maximum number of process identifiers that can be stored in the *lpdwProcessList* buffer. This must be greater than 0 and refer to the length of `lpdwProcessList`.
 
 Return value
 ------------
@@ -56,6 +56,8 @@ If the function succeeds, the return value is less than or equal to *dwProcessCo
 If the buffer is too small to hold all the valid process identifiers, the return value is the required number of array elements. The function will have stored no identifiers in the buffer. In this situation, use the return value to allocate a buffer that is large enough to store the entire list and call the function again.
 
 If the return value is zero, the function has failed, because every console has at least one process associated with it. To get extended error information, call [**GetLastError**](https://msdn.microsoft.com/library/windows/desktop/ms679360).
+
+If a `NULL` process list was provided or the process count was 0, the call will return 0 and `GetLastError` will return `ERROR_INVALID_PARAMETER`. Please provide a buffer of at least one element to call this function. Allocate a larger buffer and call again if the return code is larger than the length of the provided buffer.
 
 Remarks
 -------


### PR DESCRIPTION
…ect that calling with a null buffer or a 0 length buffer will fail. MSFT#19193481 and MicrosoftDocs/Console-Docs#32