### PR TITLE
Fix error in downlevel text

### DIFF
--- a/docs/console-virtual-terminal-sequences.md
+++ b/docs/console-virtual-terminal-sequences.md
@@ -591,7 +591,7 @@ The following code provides an example of the recommended way to enable virtual 
 
 1. The existing mode should always be retrieved via GetConsoleMode and analyzed before being set with SetConsoleMode.
 
-2. Checking whether SetConsoleMode returns `0` and GetLastError returns STATUS\_INVALID\_PARAMETER is the current mechanism to determine when running on a down-level system. An application receiving STATUS\_INVALID\_PARAMETER with one of the newer console mode flags in the bit field should gracefully degrade behavior and try again.
+2. Checking whether SetConsoleMode returns `0` and GetLastError returns ERROR\_INVALID\_PARAMETER is the current mechanism to determine when running on a down-level system. An application receiving ERROR\_INVALID\_PARAMETER with one of the newer console mode flags in the bit field should gracefully degrade behavior and try again.
 
 ```C
 #include <stdio.h>


### PR DESCRIPTION
On a down-level system such as Windows 7, `GetLastError` returns `ERROR_INVALID_PARAMETER` (87) rather than `STATUS_INVALID_PARAMETER` (0xC000000D).  `STATUS_INVALID_PARAMETER` is a kernel error constant. 

Fixing this to save others wasting the hour I just wasted :)