### PR TITLE
missing article

### DIFF
--- a/docs/allocconsole.md
+++ b/docs/allocconsole.md
@@ -60,7 +60,7 @@ If the calling process creates a child process, the child inherits the new conso
 
 **AllocConsole** initializes standard input, standard output, and standard error handles for the new console. The standard input handle is a handle to the console's input buffer, and the standard output and standard error handles are handles to the console's screen buffer. To retrieve these handles, use the [**GetStdHandle**](getstdhandle.md) function.
 
-This function is primarily used by graphical user interface (GUI) application to create a console window. GUI applications are initialized without a console. Console applications are initialized with a console, unless they are created as detached processes (by calling the [**CreateProcess**](https://msdn.microsoft.com/library/windows/desktop/ms682425) function with the **DETACHED\_PROCESS** flag).
+This function is primarily used by a graphical user interface (GUI) application to create a console window. GUI applications are initialized without a console. Console applications are initialized with a console, unless they are created as detached processes (by calling the [**CreateProcess**](https://msdn.microsoft.com/library/windows/desktop/ms682425) function with the **DETACHED\_PROCESS** flag).
 
 Requirements
 ------------


### PR DESCRIPTION
Changed sentence from: This function is primarily used by graphical user interface (GUI) application to create a console window.
To: This function is primarily used by a graphical user interface (GUI) application to create a console window.