### PR TITLE
Typo + Grammar

### DIFF
--- a/docs/consoles.md
+++ b/docs/consoles.md
@@ -17,9 +17,9 @@ ms.assetid: 16148ce6-d3be-40dd-b82e-50ea1df67c4e
 
 # Consoles
 
-A *console* (or "terminal) is an application that provides I/O to character-mode applications. This processor-independent mechanism makes it easy to port existing character-mode applications or to create new character-mode tools and applications.
+A *console* (or *terminal*) is an application that provides I/O to character-mode applications. This processor-independent mechanism makes it easy to port existing character-mode applications or to create new character-mode tools and applications.
 
-A console consists of an input buffer and one or more screen buffers. The *input buffer* contains a queue of input records, each of which contains information about an input event. The input queue always includes key-press and key-release events. It can also include mouse events (pointer movements and button presses and releases) and events during which user actions affect the size of the active screen buffer. A *screen buffer* is a two-dimensional array of character and color data for output in a console window. Any number of processes can share a console.
+A console consists of an input buffer and one or more screen buffers. The *input buffer* contains a queue of input records, each of which contains information about an input event. The input queue always includes key-press and key-release events. It may also include mouse events (pointer movements and button presses and releases) and events during which user actions affect the size of the active screen buffer. A *screen buffer* is a two-dimensional array of character and color data for output in a console window. Any number of processes can share a console.
 
 - [Creation of a Console](creation-of-a-console.md)
 - [Attaching to a Console](attaching-to-a-console.md)


### PR DESCRIPTION
- wrap *terminal* in italics for consistency
- swap "can" for "may"