### PR TITLE
Fixed link on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Windows Console Documentation
 Welcome to the Windows Console documentation repo. The MSDN Console Docs are generated from the markdown stored in this repo.
-The published docs can be found at [https://docs.microsoft.com/windows/console/]()
+The published docs can be found at [https://docs.microsoft.com/windows/console/](https://docs.microsoft.com/windows/console/)
 
 For code issues related to the Windows Console, Windows Terminal, and related command-line and terminal tooling products acquired with Windows, from the Windows Store, or other sources like GitHub, please check out the [Microsoft/Terminal](https://github.com/microsoft/terminal) repository.
 


### PR DESCRIPTION
The <https://docs.microsoft.com/windows/console/> link was not set which caused a click on it to redirect to <https://github.com/MicrosoftDocs/Console-Docs/blob/master>.