### PR TITLE
Document a couple missed apisets

### DIFF
--- a/docs/peekconsoleinput.md
+++ b/docs/peekconsoleinput.md
@@ -33,6 +33,7 @@ api_name:
 api_location:
 - Kernel32.dll
 - API-MS-Win-Core-Console-l1-1-0.dll
+- API-MS-Win-Core-Console-l1-2-0.dll
 - KernelBase.dll
 - API-MS-Win-Core-Console-l2-1-0.dll
 - API-MS-Win-DownLevel-Kernel32-l1-1-0.dll

--- a/docs/setconsoletitle.md
+++ b/docs/setconsoletitle.md
@@ -38,6 +38,7 @@ api_location:
 - API-MS-Win-Core-Kernel32-Legacy-l1-1-2.dll
 - API-MS-Win-DownLevel-Kernel32-l2-1-0.dll
 - API-MS-Win-Core-Console-l2-1-0.dll
+- API-MS-Win-Core-Console-l2-2-0.dll
 - KernelBase.dll
 - API-MS-Win-DownLevel-Kernel32-l1-1-0.dll
 - API-MS-Win-Core-Kernel32-Legacy-L1-1-3.dll


### PR DESCRIPTION
PeekConsoleInputW was moved to l1 in l1-2; SetConsoleTitle is visible through both versions of its apiset and apparently we need to document that.