### PR TITLE
Bulk fix - Removing .localizationpriority

### DIFF
--- a/docs/allocconsole.md
+++ b/docs/allocconsole.md
@@ -29,7 +29,6 @@ api_location:
 - MinKernelBase.dll
 api_type:
 - DllExport
-ms.localizationpriority: high
 ---
 
 # AllocConsole function

--- a/docs/classic-vs-vt.md
+++ b/docs/classic-vs-vt.md
@@ -6,7 +6,6 @@ ms.author: miniksa
 ms.topic: conceptual
 keywords: console, terminal, virtual terminal, escape sequences, vt, vt100, console api
 ms.prod: console
-ms.localizationpriority: high
 ---
 
 # Classic Console APIs versus Virtual Terminal Sequences

--- a/docs/console-handles.md
+++ b/docs/console-handles.md
@@ -13,7 +13,6 @@ MSHAttr:
 - 'PreferredSiteName:MSDN'
 - 'PreferredLib:/library/windows/desktop'
 ms.assetid: dc723046-b3e9-418a-b386-79be411e5ac8
-ms.localizationpriority: high
 ---
 
 # Console Handles

--- a/docs/console-screen-buffers.md
+++ b/docs/console-screen-buffers.md
@@ -13,7 +13,6 @@ MSHAttr:
 - 'PreferredSiteName:MSDN'
 - 'PreferredLib:/library/windows/desktop'
 ms.assetid: f94995fc-5f5f-4fcd-969d-7e10020634c2
-ms.localizationpriority: high
 ---
 
 # Console Screen Buffers

--- a/docs/creating-a-pseudoconsole-session.md
+++ b/docs/creating-a-pseudoconsole-session.md
@@ -6,7 +6,6 @@ ms.author: miniksa
 ms.topic: conceptual
 ms.prod: console
 keywords: console, character mode applications, command line applications, terminal applications, console api, conpty, pseudoconsole, windows pty, pseudo console
-ms.localizationpriority: high
 ---
 
 # Creating a Pseudoconsole session

--- a/docs/creation-of-a-console.md
+++ b/docs/creation-of-a-console.md
@@ -13,7 +13,6 @@ MSHAttr:
 - 'PreferredSiteName:MSDN'
 - 'PreferredLib:/library/windows/desktop'
 ms.assetid: 84ec2559-cade-447e-8594-5b824d3d3e81
-ms.localizationpriority: high
 ---
 
 # Creation of a Console

--- a/docs/ctrl-c-and-ctrl-break-signals.md
+++ b/docs/ctrl-c-and-ctrl-break-signals.md
@@ -13,7 +13,6 @@ MSHAttr:
 - 'PreferredSiteName:MSDN'
 - 'PreferredLib:/library/windows/desktop'
 ms.assetid: 5357ed99-920b-47a0-a922-d5faed7bf23e
-ms.localizationpriority: high
 ---
 
 # CTRL+C and CTRL+BREAK Signals

--- a/docs/ecosystem-roadmap.md
+++ b/docs/ecosystem-roadmap.md
@@ -6,7 +6,6 @@ ms.author: miniksa
 ms.topic: conceptual
 keywords: console, terminal, virtual terminal, console host, command-line, subsystem, roadmap, ecosystem
 ms.prod: console
-ms.localizationpriority: high
 ---
 
 # Windows Console and Terminal Ecosystem Roadmap

--- a/docs/getstdhandle.md
+++ b/docs/getstdhandle.md
@@ -31,7 +31,6 @@ api_location:
 - MinKernelBase.dll
 api_type:
 - DllExport
-ms.localizationpriority: high
 ---
 
 # GetStdHandle function

--- a/docs/setconsolectrlhandler.md
+++ b/docs/setconsolectrlhandler.md
@@ -30,7 +30,6 @@ api_location:
 - MinKernelBase.dll
 api_type:
 - DllExport
-ms.localizationpriority: high
 ---
 
 # SetConsoleCtrlHandler function

--- a/docs/setconsolemode.md
+++ b/docs/setconsolemode.md
@@ -30,7 +30,6 @@ api_location:
 - MinKernelBase.dll
 api_type:
 - DllExport
-ms.localizationpriority: high
 ---
 
 # SetConsoleMode function

--- a/docs/writeconsole.md
+++ b/docs/writeconsole.md
@@ -38,7 +38,6 @@ api_location:
 - MinKernelBase.dll
 api_type:
 - DllExport
-ms.localizationpriority: high
 ---
 
 # WriteConsole function


### PR DESCRIPTION
This is a bulk fix - According to the new DevRel GX group mission, the Localization production team drives the localization priority and translation quality per customer usage data, e.g. Page View or MAU of the language. The localization priority is defined by the project setting in localization pipeline - ms.localizationpriority in the source file is no longer used as a driving parameter to define the localization priority. https://review.docs.microsoft.com/help/contribute/localization-checklist-for-writer?branch=master#stop-using-mslocalizationpriority-metadata