### PR TITLE
[BrokenLinks] add breadcrumb file

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,0 +1,8 @@
+- name: Docs
+  tocHref: /
+  topicHref: /
+  items:
+
+  - name: Windows Console
+    tocHref: /windows/console/
+    topicHref: /windows/console/index


### PR DESCRIPTION
**Global effort to fix broken links**

@jken

The C+E Skilling team is fixing broken links on docs.microsoft.com. This effort will eliminate potential accessibility, security, and usability issues. This PR adds a breadcrumb TOC, which is already referenced in the docfx.json config file. This change will resolve > 100 link errors due to the missing breadcrumb. Thanks!