### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Windows Console Documentation
 
-Welcome to the Windows Console documentation repo. The published articles are generated from the markdown stored in this repo and published at [Windows Console documentation](https://docs.microsoft.com/windows/console/).
+Welcome to the Windows Console documentation repo. The published articles are generated from the markdown stored in this repo and published at [Windows Console documentation](https://learn.microsoft.com/windows/console/).
 
 For code issues related to the Windows Console, Windows Terminal, and related command-line and terminal tooling products acquired with Windows, from the Windows Store, or other sources like GitHub, please check out the [microsoft/terminal](https://github.com/microsoft/terminal) repository.
 

--- a/docs/registering-a-control-handler-function.md
+++ b/docs/registering-a-control-handler-function.md
@@ -151,13 +151,13 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_QUERYENDSESSION:
     {
         // Check `lParam` for which system shutdown function and handle events.
-        // See https://docs.microsoft.com/windows/win32/shutdown/wm-queryendsession
+        // See https://learn.microsoft.com/windows/win32/shutdown/wm-queryendsession
         return TRUE; // Respect user's intent and allow shutdown.
     }
     case WM_ENDSESSION:
     {
         // Check `lParam` for which system shutdown function and handle events.
-        // See https://docs.microsoft.com/windows/win32/shutdown/wm-endsession
+        // See https://learn.microsoft.com/windows/win32/shutdown/wm-endsession
         return 0; // We have handled this message.
     }
     default:


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
