### PR TITLE
Update getconsolewindow.md

### DIFF
--- a/docs/getconsolewindow.md
+++ b/docs/getconsolewindow.md
@@ -32,6 +32,7 @@ api_location:
 - API-MS-Win-Core-Kernel32-Legacy-L1-1-3.dll
 - API-MS-Win-Core-Kernel32-Legacy-L1-1-4.dll
 - API-MS-Win-Core-Kernel32-Legacy-L1-1-5.dll
+- api-ms-win-core-console-l3-2-0.dll
 api_type:
 - DllExport
 ---


### PR DESCRIPTION
This update is adding api-ms-win-core-console-l3-2-0.dll to the api_location metadata. I'm working on a spreadsheet of random APIScan hits. Most of them are in the Windows SDK, which is why the task fell on me. This is the only API in the console docs.