### PR TITLE
Fix typo CONSOLE_READ_NOMOVE -> CONSOLE_READ_NOREMOVE in ReadConsoleInputEx docs

### DIFF
--- a/docs/readconsoleinputex.md
+++ b/docs/readconsoleinputex.md
@@ -91,7 +91,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 This function is a configurable version of `ReadConsoleInput`. See the [remarks for `ReadConsoleInput`](readconsoleinput.md) for additional operational details.
 
-Calling `ReadConsoleInputEx` with the flags `CONSOLE_READ_NOMOVE | CONSOLE_READ_NOWAIT` is equivalent to calling [`PeekConsoleInput`](peekconsoleinput.md).
+Calling `ReadConsoleInputEx` with the flags `CONSOLE_READ_NOREMOVE | CONSOLE_READ_NOWAIT` is equivalent to calling [`PeekConsoleInput`](peekconsoleinput.md).
 
 This function does not exist in the Windows Console headers. To gain access to it from a C or C++ application, include the following declarations and dynamically link kernel32.dll as noted above.
 


### PR DESCRIPTION
There's a single occurrence of `CONSOLE_READ_NOMOVE` in the Remarks section. The flag is named `CONSOLE_READ_NOREMOVE` a few times elsewhere on the page. According to the docs, the function and flags aren't in any SDK header, and not in kernel32 implib, so there's no ground source of truth. Please check if it has been internally added, and if so under which flag name.