### PR TITLE
Fix ExitError() param type in reading-input-buffer-events.md

### DIFF
--- a/docs/reading-input-buffer-events.md
+++ b/docs/reading-input-buffer-events.md
@@ -104,7 +104,7 @@ int main(VOID)
     return 0;
 }
 
-VOID ErrorExit (LPSTR lpszMessage)
+VOID ErrorExit (LPCSTR lpszMessage)
 {
     fprintf(stderr, "%s\n", lpszMessage);
 


### PR DESCRIPTION
The declaration uses a constant string pointer but the definition had used a non-constant string pointer.
The example only uses constant strings, so unifying the types to LPCSTR should be okay. Otherwise, both should be LPSTR to anticipate non-constant strings.